### PR TITLE
Remove unused global 'HUD_ENABLE_HUNGER'

### DIFF
--- a/builtin.lua
+++ b/builtin.lua
@@ -38,7 +38,7 @@ hud.show_armor = minetest.get_modpath("3d_armor") ~= nil
 
 -- check if some settings are invalid
 local enable_hunger = minetest.setting_getbool("hud_hunger_enable")
-if (enable_hunger == true or HUD_ENABLE_HUNGER == true) and not hud.show_hunger then
+if enable_hunger == true and not hud.show_hunger then
 	hud.notify_hunger(5)
 end
 


### PR DESCRIPTION
*HUD_ENABLE_HUNGER* does not appear to be declared anywhere.